### PR TITLE
fix: Correct working directory in run scripts

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -12,10 +12,14 @@ IF NOT EXIST "%VENV_DIR%" (
     GOTO:EOF
 )
 
-REM Run the Uvicorn server from the root directory using the venv's python
+REM Change to the backend directory
+ECHO Changing to backend directory...
+cd backend
+
+REM Run the Uvicorn server from within the backend directory
 ECHO Starting FastAPI server with Uvicorn...
 ECHO Access the dashboard at http://localhost:8000
-.\%VENV_DIR%\Scripts\uvicorn.exe backend.app.main:app --host 0.0.0.0 --port 8000 --app-dir .
+..\%VENV_DIR%\Scripts\uvicorn.exe app.main:app --host 0.0.0.0 --port 8000
 
 REM The server will run until you stop it with Ctrl+C
 ECHO Server stopped.

--- a/run.sh
+++ b/run.sh
@@ -12,10 +12,14 @@ if [ ! -d "$VENV_DIR" ]; then
     exit 1
 fi
 
-# Run the Uvicorn server from the root directory using the venv's python
+# Change to the backend directory
+echo "Changing to backend directory..."
+cd backend
+
+# Run the Uvicorn server from within the backend directory
 echo "Starting FastAPI server with Uvicorn..."
 echo "Access the dashboard at http://localhost:8000"
-$VENV_DIR/bin/uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --app-dir .
+../$VENV_DIR/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 # The server will run until you stop it with Ctrl+C
 echo "Server stopped."


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError: No module named 'app'` that occurred when running the application.

The `run.sh` and `run.bat` scripts are updated to change into the `backend/` directory before executing the `uvicorn` command. This ensures that the Python interpreter can correctly locate the `app` module and its sub-packages.

This change resolves the startup error and allows the application to be run correctly on both Windows and Linux.